### PR TITLE
Fixed options not passed to the recursive function

### DIFF
--- a/lib/recursive-files.js
+++ b/lib/recursive-files.js
@@ -28,7 +28,7 @@ function read (dir, options, callback) {
         if (err) callback(err)
 
         // if it's a directory we do the whole thing for it
-        else if (stats.isDirectory()) read(file, callback);
+        else if (stats.isDirectory()) read(file, options, callback);
 
         else {
           // separating some info


### PR DESCRIPTION
The `options` were not passed to the recursive function call, implying files deeper than the base dir were not matched against it.